### PR TITLE
SF-03 pages: optimize settings page with user preferences

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -3,7 +3,9 @@
     "pages/market/market",
     "pages/index/index",
     "pages/logs/logs",
-    "pages/calendar/calendar"
+    "pages/calendar/calendar",
+    "pages/about/about",
+    "pages/feedback/feedback"
   ],
   "window": {
     "navigationBarTextStyle": "black",

--- a/miniprogram/pages/about/about.json
+++ b/miniprogram/pages/about/about.json
@@ -3,8 +3,6 @@
     "navigation-bar": "/components/navigation-bar/navigation-bar",
     "van-cell": "@vant/weapp/cell/index",
     "van-cell-group": "@vant/weapp/cell-group/index",
-    "van-icon": "@vant/weapp/icon/index",
-    "van-switch": "@vant/weapp/switch/index",
-    "van-action-sheet": "@vant/weapp/action-sheet/index"
+    "van-icon": "@vant/weapp/icon/index"
   }
 }

--- a/miniprogram/pages/about/about.less
+++ b/miniprogram/pages/about/about.less
@@ -1,0 +1,180 @@
+/**about.less**/
+
+@bg-color: #F5F6F8;
+@surface-color: #FFFFFF;
+@primary-color: #2F54EB;
+@text-main: #1A1D24;
+@text-secondary: #8C92A4;
+@border-color: #EBF0F5;
+
+page {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: @bg-color;
+}
+
+.scrollarea {
+  flex: 1;
+  overflow-y: hidden;
+}
+
+.about-page {
+  padding-bottom: calc(48rpx + env(safe-area-inset-bottom));
+}
+
+// ==========================================
+// Brand Section
+// ==========================================
+.brand-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 72rpx 40rpx 56rpx;
+  background: linear-gradient(180deg, rgba(47, 84, 235, 0.06) 0%, transparent 100%);
+}
+
+.logo-wrap {
+  margin-bottom: 28rpx;
+}
+
+.logo-icon {
+  width: 128rpx;
+  height: 128rpx;
+  border-radius: 32rpx;
+  background: linear-gradient(135deg, #2F54EB 0%, #597EF7 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 12rpx 32rpx rgba(47, 84, 235, 0.3);
+}
+
+.logo-text {
+  font-size: 48rpx;
+  font-weight: 700;
+  color: #FFFFFF;
+  letter-spacing: 4rpx;
+}
+
+.app-name {
+  font-size: 40rpx;
+  font-weight: 700;
+  color: @text-main;
+  margin-bottom: 12rpx;
+}
+
+.app-tagline {
+  font-size: 26rpx;
+  color: @text-secondary;
+  margin-bottom: 16rpx;
+}
+
+.app-version {
+  font-size: 24rpx;
+  color: @text-secondary;
+  background-color: rgba(47, 84, 235, 0.08);
+  padding: 6rpx 20rpx;
+  border-radius: 20rpx;
+}
+
+// ==========================================
+// Info Cards
+// ==========================================
+.info-card {
+  margin: 0 24rpx 20rpx;
+  padding: 36rpx 36rpx;
+  background-color: @surface-color;
+  border-radius: 24rpx;
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.02);
+}
+
+.card-title {
+  font-size: 30rpx;
+  font-weight: 600;
+  color: @text-main;
+  margin-bottom: 20rpx;
+  display: flex;
+  align-items: center;
+
+  &::before {
+    content: '';
+    display: inline-block;
+    width: 8rpx;
+    height: 28rpx;
+    background-color: @primary-color;
+    border-radius: 4rpx;
+    margin-right: 16rpx;
+  }
+}
+
+.card-body {
+  font-size: 27rpx;
+  color: @text-secondary;
+  line-height: 1.8;
+}
+
+// ==========================================
+// Features
+// ==========================================
+.feature-list {
+  padding-left: 8rpx;
+}
+
+.feature-item {
+  display: flex;
+  align-items: center;
+  padding: 14rpx 0;
+  font-size: 27rpx;
+  color: @text-main;
+}
+
+.feature-dot {
+  width: 12rpx;
+  height: 12rpx;
+  border-radius: 50%;
+  background-color: @primary-color;
+  margin-right: 20rpx;
+  flex-shrink: 0;
+}
+
+// ==========================================
+// Contact Group
+// ==========================================
+.contact-group {
+  margin: 0 24rpx 20rpx;
+  border-radius: 24rpx !important;
+  overflow: hidden;
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.02);
+}
+
+.contact-cell {
+  font-size: 28rpx;
+}
+
+.support-emails {
+  display: flex;
+  flex-direction: column;
+  text-align: right;
+  line-height: 1.6;
+  color: @text-secondary;
+  word-break: break-all;
+  white-space: normal;
+}
+
+.cell-icon {
+  margin-right: 20rpx;
+  font-size: 36rpx;
+}
+
+// ==========================================
+// Footer
+// ==========================================
+.footer {
+  padding: 48rpx 40rpx 24rpx;
+  text-align: center;
+}
+
+.copyright {
+  font-size: 22rpx;
+  color: @text-secondary;
+}

--- a/miniprogram/pages/about/about.ts
+++ b/miniprogram/pages/about/about.ts
@@ -1,0 +1,6 @@
+// about.ts
+Component({
+  data: {
+    appVersion: 'v0.1.0',
+  },
+})

--- a/miniprogram/pages/about/about.wxml
+++ b/miniprogram/pages/about/about.wxml
@@ -1,0 +1,76 @@
+<!--about.wxml-->
+<navigation-bar title="关于我们" back="{{true}}" color="black" background="#FFF"></navigation-bar>
+<scroll-view class="scrollarea" scroll-y type="list">
+  <view class="about-page">
+
+    <!-- Logo & Brand -->
+    <view class="brand-section">
+      <view class="logo-wrap">
+        <view class="logo-icon">
+          <text class="logo-text">SF</text>
+        </view>
+      </view>
+      <text class="app-name">StocksFlow</text>
+      <text class="app-tagline">全球股市交易时间 · 一目了然</text>
+      <text class="app-version">Version {{appVersion}}</text>
+    </view>
+
+    <!-- App Description -->
+    <view class="info-card">
+      <text class="card-title">关于应用</text>
+      <text class="card-body">StocksFlow 是一款专注于全球股市交易时间追踪的工具型小程序。我们致力于为投资者提供清晰、准确的市场交易时间、假日安排及倒计时提醒，帮助您高效把握每一个交易机会。</text>
+    </view>
+
+    <!-- Features -->
+    <view class="info-card">
+      <text class="card-title">核心功能</text>
+      <view class="feature-list">
+        <view class="feature-item">
+          <view class="feature-dot"></view>
+          <text>全球主要市场交易时间实时显示</text>
+        </view>
+        <view class="feature-item">
+          <view class="feature-dot"></view>
+          <text>盘前 / 盘中 / 盘后状态可视化</text>
+        </view>
+        <view class="feature-item">
+          <view class="feature-dot"></view>
+          <text>市场假期日历与智能提醒</text>
+        </view>
+        <view class="feature-item">
+          <view class="feature-dot"></view>
+          <text>个性化市场偏好配置</text>
+        </view>
+      </view>
+    </view>
+
+    <!-- Contact -->
+    <van-cell-group title="联系我们" border="{{false}}" custom-class="contact-group">
+      <van-cell
+        title="开发团队"
+        value="StocksFlow Team"
+        custom-class="contact-cell"
+      >
+        <van-icon slot="icon" name="friends-o" class="cell-icon" color="#2F54EB" />
+      </van-cell>
+      <van-cell
+        title="技术支持"
+        title-width="160rpx"
+        center
+        custom-class="contact-cell"
+      >
+        <van-icon slot="icon" name="envelop-o" class="cell-icon" color="#13C2C2" />
+        <view class="support-emails">
+          <view>weizhao.days@gmail.com</view>
+          <view>ixpqxi@qq.com</view>
+        </view>
+      </van-cell>
+    </van-cell-group>
+
+    <!-- Footer -->
+    <view class="footer">
+      <text class="copyright">© 2026 StocksFlow. All rights reserved.</text>
+    </view>
+
+  </view>
+</scroll-view>

--- a/miniprogram/pages/feedback/feedback.json
+++ b/miniprogram/pages/feedback/feedback.json
@@ -4,7 +4,6 @@
     "van-cell": "@vant/weapp/cell/index",
     "van-cell-group": "@vant/weapp/cell-group/index",
     "van-icon": "@vant/weapp/icon/index",
-    "van-switch": "@vant/weapp/switch/index",
-    "van-action-sheet": "@vant/weapp/action-sheet/index"
+    "van-button": "@vant/weapp/button/index"
   }
 }

--- a/miniprogram/pages/feedback/feedback.less
+++ b/miniprogram/pages/feedback/feedback.less
@@ -1,0 +1,165 @@
+/**feedback.less**/
+
+@bg-color: #F5F6F8;
+@surface-color: #FFFFFF;
+@primary-color: #2F54EB;
+@text-main: #1A1D24;
+@text-secondary: #8C92A4;
+@border-color: #EBF0F5;
+
+page {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: @bg-color;
+}
+
+.scrollarea {
+  flex: 1;
+  overflow-y: hidden;
+}
+
+.feedback-page {
+  padding: 24rpx 24rpx calc(48rpx + env(safe-area-inset-bottom));
+}
+
+// ==========================================
+// Section Title
+// ==========================================
+.section-title {
+  font-size: 28rpx;
+  font-weight: 600;
+  color: @text-main;
+  margin-bottom: 20rpx;
+  padding-left: 8rpx;
+  display: flex;
+  align-items: center;
+
+  &::before {
+    content: '';
+    display: inline-block;
+    width: 6rpx;
+    height: 24rpx;
+    background-color: @primary-color;
+    border-radius: 3rpx;
+    margin-right: 14rpx;
+  }
+}
+
+// ==========================================
+// Category Chips
+// ==========================================
+.category-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
+  margin-bottom: 40rpx;
+}
+
+.category-chip {
+  display: flex;
+  align-items: center;
+  padding: 16rpx 28rpx;
+  background-color: @surface-color;
+  border-radius: 40rpx;
+  border: 2rpx solid @border-color;
+  transition: all 0.25s ease;
+
+  .chip-icon {
+    font-size: 28rpx;
+    margin-right: 10rpx;
+  }
+
+  .chip-label {
+    font-size: 26rpx;
+    color: @text-main;
+  }
+
+  &.active {
+    background-color: rgba(47, 84, 235, 0.08);
+    border-color: @primary-color;
+
+    .chip-label {
+      color: @primary-color;
+      font-weight: 600;
+    }
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+}
+
+// ==========================================
+// Textarea
+// ==========================================
+.textarea-wrap {
+  position: relative;
+  background-color: @surface-color;
+  border-radius: 24rpx;
+  padding: 28rpx;
+  margin-bottom: 40rpx;
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.02);
+}
+
+.feedback-textarea {
+  width: 100%;
+  height: 280rpx;
+  font-size: 28rpx;
+  color: @text-main;
+  line-height: 1.7;
+  box-sizing: border-box;
+}
+
+.char-count {
+  display: block;
+  text-align: right;
+  font-size: 22rpx;
+  color: @text-secondary;
+  margin-top: 12rpx;
+}
+
+// ==========================================
+// Contact Input
+// ==========================================
+.contact-input-wrap {
+  background-color: @surface-color;
+  border-radius: 24rpx;
+  padding: 24rpx 28rpx;
+  margin-bottom: 48rpx;
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.02);
+}
+
+.contact-input {
+  width: 100%;
+  font-size: 28rpx;
+  color: @text-main;
+}
+
+// ==========================================
+// Submit Button
+// ==========================================
+.submit-section {
+  margin-bottom: 32rpx;
+}
+
+.submit-btn {
+  font-size: 30rpx !important;
+  font-weight: 600 !important;
+  height: 88rpx !important;
+  box-shadow: 0 8rpx 24rpx rgba(47, 84, 235, 0.25);
+}
+
+// ==========================================
+// Tip Section
+// ==========================================
+.tip-section {
+  text-align: center;
+  padding: 16rpx 40rpx;
+}
+
+.tip-text {
+  font-size: 24rpx;
+  color: @text-secondary;
+  line-height: 1.6;
+}

--- a/miniprogram/pages/feedback/feedback.ts
+++ b/miniprogram/pages/feedback/feedback.ts
@@ -1,0 +1,66 @@
+// feedback.ts
+Component({
+  data: {
+    categories: [
+      { label: '功能建议', value: 'feature', icon: '💡' },
+      { label: 'Bug 报告', value: 'bug', icon: '🐛' },
+      { label: '界面优化', value: 'ui', icon: '🎨' },
+      { label: '数据问题', value: 'data', icon: '📊' },
+      { label: '其他', value: 'other', icon: '💬' },
+    ],
+    selectedCategory: '',
+    content: '',
+    contact: '',
+    canSubmit: false,
+  },
+
+  methods: {
+    onSelectCategory(e: WechatMiniprogram.TouchEvent) {
+      const { value } = e.currentTarget.dataset
+      this.setData({ selectedCategory: value })
+      this.checkCanSubmit()
+    },
+
+    onInput(e: any) {
+      this.setData({ content: e.detail.value })
+      this.checkCanSubmit()
+    },
+
+    onContactInput(e: any) {
+      this.setData({ contact: e.detail.value })
+    },
+
+    checkCanSubmit() {
+      const { selectedCategory, content } = this.data
+      this.setData({
+        canSubmit: !!selectedCategory && content.length >= 10,
+      })
+    },
+
+    onSubmit() {
+      if (!this.data.canSubmit) return
+
+      const { selectedCategory, content, contact } = this.data
+
+      // TODO: Send to backend API
+      console.log('Feedback submitted:', { selectedCategory, content, contact })
+
+      wx.showToast({
+        title: '反馈已提交，感谢您！',
+        icon: 'none',
+        duration: 2000,
+      })
+
+      // Reset form
+      setTimeout(() => {
+        this.setData({
+          selectedCategory: '',
+          content: '',
+          contact: '',
+          canSubmit: false,
+        })
+        wx.navigateBack()
+      }, 1500)
+    },
+  },
+})

--- a/miniprogram/pages/feedback/feedback.wxml
+++ b/miniprogram/pages/feedback/feedback.wxml
@@ -1,0 +1,66 @@
+<!--feedback.wxml-->
+<navigation-bar title="意见反馈" back="{{true}}" color="black" background="#FFF"></navigation-bar>
+<scroll-view class="scrollarea" scroll-y type="list">
+  <view class="feedback-page">
+
+    <!-- Category selector -->
+    <view class="section-title">反馈类型</view>
+    <view class="category-grid">
+      <view
+        wx:for="{{categories}}"
+        wx:key="value"
+        class="category-chip {{selectedCategory === item.value ? 'active' : ''}}"
+        bindtap="onSelectCategory"
+        data-value="{{item.value}}"
+      >
+        <text class="chip-icon">{{item.icon}}</text>
+        <text class="chip-label">{{item.label}}</text>
+      </view>
+    </view>
+
+    <!-- Feedback content -->
+    <view class="section-title">详细描述</view>
+    <view class="textarea-wrap">
+      <textarea
+        class="feedback-textarea"
+        placeholder="请详细描述您遇到的问题或建议..."
+        maxlength="500"
+        bindinput="onInput"
+        value="{{content}}"
+      />
+      <text class="char-count">{{content.length}}/500</text>
+    </view>
+
+    <!-- Contact -->
+    <view class="section-title">联系方式（选填）</view>
+    <view class="contact-input-wrap">
+      <input
+        class="contact-input"
+        placeholder="邮箱或手机号，方便我们回复您"
+        bindinput="onContactInput"
+        value="{{contact}}"
+      />
+    </view>
+
+    <!-- Submit -->
+    <view class="submit-section">
+      <van-button
+        type="primary"
+        block
+        round
+        color="#2F54EB"
+        custom-class="submit-btn"
+        disabled="{{!canSubmit}}"
+        bindtap="onSubmit"
+      >
+        提交反馈
+      </van-button>
+    </view>
+
+    <!-- Tip -->
+    <view class="tip-section">
+      <text class="tip-text">💡 您的每一条反馈都将帮助我们做得更好，感谢您的支持！</text>
+    </view>
+
+  </view>
+</scroll-view>

--- a/miniprogram/pages/index/index.less
+++ b/miniprogram/pages/index/index.less
@@ -1,33 +1,68 @@
 /**index.less**/
+
+// ── Design Tokens (consistent with market.less) ──
+@bg-color: #F5F6F8;
+@surface-color: #FFFFFF;
+@primary-color: #2F54EB;
+@text-main: #1A1D24;
+@text-secondary: #8C92A4;
+@border-color: #EBF0F5;
+
 page {
   height: 100vh;
   display: flex;
   flex-direction: column;
+  background-color: @bg-color;
 }
+
 .scrollarea {
   flex: 1;
   overflow-y: hidden;
 }
 
-.userinfo {
+.page-content {
+  padding-bottom: calc(32rpx + env(safe-area-inset-bottom));
+}
+
+// ==========================================
+// Profile Card
+// ==========================================
+.profile-card {
+  position: relative;
+  margin: 0 0 24rpx;
+  overflow: hidden;
+}
+
+.profile-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 280rpx;
+  background: linear-gradient(135deg, #7485db 0%, #e8eaf7 40%, #5668ce 100%);
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -40rpx;
+    left: -10%;
+    right: -10%;
+    height: 80rpx;
+    background-color: @bg-color;
+    border-radius: 50% 50% 0 0;
+  }
+}
+
+.profile-body {
+  position: relative;
+  z-index: 2;
   display: flex;
   flex-direction: column;
   align-items: center;
-  color: #aaa;
-  width: 80%;
+  padding: 48rpx 40rpx 40rpx;
+  min-height: 260rpx;
 }
 
-.userinfo-avatar {
-  overflow: hidden;
-  width: 128rpx;
-  height: 128rpx;
-  margin: 20rpx;
-  border-radius: 50%;
-}
-
-.usermotto {
-  margin-top: 200px;
-}
 .avatar-wrapper {
   padding: 0;
   width: 56px !important;
@@ -41,6 +76,29 @@ page {
   width: 56px;
   height: 56px;
 }
+// // ── Avatar (not logged in) ──
+// .avatar-wrapper {
+//   padding: 0;
+//   width: 128rpx !important;
+//   height: 128rpx;
+//   border-radius: 50%;
+//   margin-bottom: 24rpx;
+//   border: 6rpx solid rgba(255, 255, 255, 0.9);
+//   box-shadow: 0 8rpx 24rpx rgba(47, 84, 235, 0.25);
+//   overflow: hidden;
+//   background: none;
+
+//   &::after {
+//     border: none;
+//   }
+// }
+
+// .avatar {
+//   display: block;
+//   width: 128rpx;
+//   height: 128rpx;
+//   border-radius: 50%;
+// }
 
 .nickname-wrapper {
   display: flex;
@@ -58,4 +116,113 @@ page {
 
 .nickname-input {
   flex: 1;
+}
+
+// // ── Nickname input row ──
+// .nickname-wrapper {
+//   display: flex;
+//   width: 80%;
+//   padding: 20rpx 28rpx;
+//   box-sizing: border-box;
+//   background-color: @surface-color;
+//   border-radius: 16rpx;
+//   box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.04);
+//   margin-top: 16rpx;
+// }
+
+// .nickname-label {
+//   width: 100rpx;
+//   font-size: 28rpx;
+//   color: @text-main;
+//   font-weight: 500;
+// }
+
+// .nickname-input {
+//   flex: 1;
+//   font-size: 28rpx;
+//   color: @text-main;
+// }
+
+// ── Login button (fallback) ──
+.login-btn {
+  margin-top: 60rpx;
+  padding: 0 64rpx;
+  height: 80rpx;
+  line-height: 80rpx;
+  font-size: 28rpx;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, #2F54EB, #597EF7);
+  border-radius: 40rpx;
+  border: none;
+  box-shadow: 0 8rpx 24rpx rgba(47, 84, 235, 0.3);
+
+  &::after {
+    border: none;
+  }
+}
+
+.compat-tip {
+  margin-top: 60rpx;
+  font-size: 26rpx;
+  color: @text-secondary;
+}
+
+// ── Logged in state ──
+.userinfo-avatar {
+  width: 128rpx;
+  height: 128rpx;
+  border-radius: 50%;
+  margin-bottom: 20rpx;
+  border: 6rpx solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 8rpx 24rpx rgba(47, 84, 235, 0.25);
+}
+
+.userinfo-nickname {
+  font-size: 36rpx;
+  font-weight: 600;
+  color: @text-main;
+  margin-top: 8rpx;
+}
+
+// ==========================================
+// Settings Groups
+// ==========================================
+.settings-group {
+  margin: 0 24rpx 20rpx;
+  border-radius: 24rpx !important;
+  overflow: hidden;
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.02);
+}
+
+.settings-cell {
+  font-size: 28rpx;
+}
+
+.cell-icon {
+  margin-right: 20rpx;
+  font-size: 36rpx;
+}
+
+// ==========================================
+// Logout Button
+// ==========================================
+.logout-section {
+  margin: 40rpx 24rpx 32rpx;
+}
+
+.logout-btn {
+  text-align: center;
+  padding: 24rpx 0;
+  font-size: 30rpx;
+  font-weight: 500;
+  color: #FF4D4F;
+  background-color: @surface-color;
+  border-radius: 24rpx;
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.02);
+  transition: background-color 0.2s ease;
+
+  &:active {
+    background-color: rgba(255, 77, 79, 0.06);
+  }
 }

--- a/miniprogram/pages/index/index.ts
+++ b/miniprogram/pages/index/index.ts
@@ -3,8 +3,36 @@
 const app = getApp<IAppOption>()
 const defaultAvatarUrl = 'https://mmbiz.qpic.cn/mmbiz/icTdbqWNOwNRna42FI242Lcia07jQodd2FJGIYQfG0LAJGFxM4FbnQP6yfMxBgJ0F3YRqJCJ1aPAK2dQagdusBZg/0'
 
+// ── Label maps ──
+const THEME_MAP: Record<string, string> = {
+  system: '跟随系统',
+  light: '浅色模式',
+  dark: '深色模式',
+}
+
+const MARKET_MAP: Record<string, string> = {
+  cn: 'A股',
+  hk: '港股',
+  us: '美股',
+  uk: '英股',
+}
+
+const NOTIFY_FREQ_MAP: Record<string, string> = {
+  realtime: '实时推送',
+  daily: '每日一次',
+  weekly: '每周一次',
+  off: '关闭',
+}
+
+const LANGUAGE_MAP: Record<string, string> = {
+  'zh-CN': '简体中文',
+  'zh-TW': '繁體中文',
+  'en': 'English',
+}
+
 Component({
   data: {
+    // ── Login (preserved) ──
     motto: 'Hello World',
     userInfo: {
       avatarUrl: defaultAvatarUrl,
@@ -13,9 +41,64 @@ Component({
     hasUserInfo: false,
     canIUseGetUserProfile: wx.canIUse('getUserProfile'),
     canIUseNicknameComp: wx.canIUse('input.type.nickname'),
+
+    // ── Theme ──
+    themeMode: 'system',
+    themeLabel: '跟随系统',
+    showThemeSheet: false,
+    themeActions: [
+      { name: '跟随系统', value: 'system' },
+      { name: '浅色模式', value: 'light' },
+      { name: '深色模式', value: 'dark' },
+    ],
+
+    // ── Language ──
+    language: 'zh-CN',
+    languageLabel: '简体中文',
+    showLanguageSheet: false,
+    languageActions: [
+      { name: '简体中文', value: 'zh-CN' },
+      { name: '繁體中文', value: 'zh-TW' },
+      { name: 'English', value: 'en' },
+    ],
+
+    // ── Market ──
+    defaultMarket: 'cn',
+    defaultMarketLabel: 'A股',
+    showMarketSheet: false,
+    marketActions: [
+      { name: 'A股 (CN)', value: 'cn' },
+      { name: '港股 (HK)', value: 'hk' },
+      { name: '美股 (US)', value: 'us' },
+      { name: '英股 (UK)', value: 'uk' },
+    ],
+
+    // ── Notification ──
+    subscriptionEnabled: true,
+    notifyFrequency: 'daily',
+    notifyFreqLabel: '每日一次',
+    showNotifySheet: false,
+    notifyActions: [
+      { name: '实时推送', value: 'realtime' },
+      { name: '每日一次', value: 'daily' },
+      { name: '每周一次', value: 'weekly' },
+      { name: '关闭', value: 'off' },
+    ],
+
+    // ── About ──
+    appVersion: 'v0.1.0',
   },
+
+  lifetimes: {
+    attached() {
+      this.loadSettings()
+    },
+  },
+
   methods: {
-    // Event handling functions
+    // ============================================================
+    // Login methods (preserved from original)
+    // ============================================================
     bindViewTap() {
       wx.navigateTo({
         url: '../logs/logs',
@@ -51,6 +134,173 @@ Component({
             userInfo: res.userInfo,
             hasUserInfo: true
           })
+        }
+      })
+    },
+
+    // ============================================================
+    // Settings persistence
+    // ============================================================
+    loadSettings() {
+      const themeMode = wx.getStorageSync('settings_themeMode') || 'system'
+      const language = wx.getStorageSync('settings_language') || 'zh-CN'
+      const defaultMarket = wx.getStorageSync('settings_defaultMarket') || 'cn'
+      const subscriptionEnabled = wx.getStorageSync('settings_subscriptionEnabled')
+      const notifyFrequency = wx.getStorageSync('settings_notifyFrequency') || 'daily'
+
+      // Load saved user info
+      const savedUserInfo = wx.getStorageSync('settings_userInfo')
+      const hasUserInfo = wx.getStorageSync('settings_hasUserInfo') || false
+
+      this.setData({
+        themeMode,
+        themeLabel: THEME_MAP[themeMode] || '跟随系统',
+        language,
+        languageLabel: LANGUAGE_MAP[language] || '简体中文',
+        defaultMarket,
+        defaultMarketLabel: MARKET_MAP[defaultMarket] || 'A股',
+        subscriptionEnabled: subscriptionEnabled === '' ? true : subscriptionEnabled,
+        notifyFrequency,
+        notifyFreqLabel: NOTIFY_FREQ_MAP[notifyFrequency] || '每日一次',
+        ...(savedUserInfo ? { userInfo: savedUserInfo, hasUserInfo } : {}),
+      })
+    },
+
+    saveSettings(key: string, value: any) {
+      wx.setStorageSync(`settings_${key}`, value)
+    },
+
+    // ============================================================
+    // Theme
+    // ============================================================
+    showThemeSheet() {
+      this.setData({ showThemeSheet: true })
+    },
+    onThemeSheetClose() {
+      this.setData({ showThemeSheet: false })
+    },
+    onThemeSelect(e: any) {
+      const { value } = e.detail
+      this.setData({
+        themeMode: value,
+        themeLabel: THEME_MAP[value],
+        showThemeSheet: false,
+      })
+      this.saveSettings('themeMode', value)
+      wx.showToast({ title: '已切换为' + THEME_MAP[value], icon: 'none', duration: 1500 })
+    },
+
+    // ============================================================
+    // Language
+    // ============================================================
+    showLanguageSheet() {
+      this.setData({ showLanguageSheet: true })
+    },
+    onLanguageSheetClose() {
+      this.setData({ showLanguageSheet: false })
+    },
+    onLanguageSelect(e: any) {
+      const { value } = e.detail
+      this.setData({
+        language: value,
+        languageLabel: LANGUAGE_MAP[value],
+        showLanguageSheet: false,
+      })
+      this.saveSettings('language', value)
+      wx.showToast({ title: '语言已设为' + LANGUAGE_MAP[value], icon: 'none', duration: 1500 })
+    },
+
+    // ============================================================
+    // Market
+    // ============================================================
+    showMarketSheet() {
+      this.setData({ showMarketSheet: true })
+    },
+    onMarketSheetClose() {
+      this.setData({ showMarketSheet: false })
+    },
+    onMarketSelect(e: any) {
+      const { value } = e.detail
+      this.setData({
+        defaultMarket: value,
+        defaultMarketLabel: MARKET_MAP[value],
+        showMarketSheet: false,
+      })
+      this.saveSettings('defaultMarket', value)
+      wx.showToast({ title: '默认市场已设为' + MARKET_MAP[value], icon: 'none', duration: 1500 })
+    },
+
+    // ============================================================
+    // Notifications
+    // ============================================================
+    onSubscriptionToggle(e: any) {
+      const enabled = e.detail
+      this.setData({ subscriptionEnabled: enabled })
+      this.saveSettings('subscriptionEnabled', enabled)
+
+      if (enabled) {
+        // Request subscription message permission
+        wx.requestSubscribeMessage({
+          tmplIds: [],  // TODO: fill in actual template IDs
+          success: () => {
+            wx.showToast({ title: '订阅消息已开启', icon: 'none' })
+          },
+          fail: () => {
+            wx.showToast({ title: '订阅授权失败', icon: 'none' })
+          }
+        })
+      } else {
+        wx.showToast({ title: '订阅消息已关闭', icon: 'none' })
+      }
+    },
+
+    showNotifySheet() {
+      this.setData({ showNotifySheet: true })
+    },
+    onNotifySheetClose() {
+      this.setData({ showNotifySheet: false })
+    },
+    onNotifyFreqSelect(e: any) {
+      const { value } = e.detail
+      this.setData({
+        notifyFrequency: value,
+        notifyFreqLabel: NOTIFY_FREQ_MAP[value],
+        showNotifySheet: false,
+      })
+      this.saveSettings('notifyFrequency', value)
+      wx.showToast({ title: '通知频率已设为' + NOTIFY_FREQ_MAP[value], icon: 'none', duration: 1500 })
+    },
+
+    // ============================================================
+    // Navigation
+    // ============================================================
+    goToAbout() {
+      wx.navigateTo({ url: '/pages/about/about' })
+    },
+    goToFeedback() {
+      wx.navigateTo({ url: '/pages/feedback/feedback' })
+    },
+
+    // ============================================================
+    // Logout
+    // ============================================================
+    onLogout() {
+      wx.showModal({
+        title: '提示',
+        content: '确定退出登录吗？',
+        success: (res) => {
+          if (res.confirm) {
+            this.setData({
+              userInfo: {
+                avatarUrl: defaultAvatarUrl,
+                nickName: '',
+              },
+              hasUserInfo: false,
+            })
+            this.saveSettings('userInfo', null)
+            this.saveSettings('hasUserInfo', false)
+            wx.showToast({ title: '已退出登录', icon: 'none' })
+          }
         }
       })
     },

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -1,28 +1,163 @@
 <!--index.wxml-->
-<navigation-bar title="Weixin" back="{{false}}" color="black" background="#FFF"></navigation-bar>
+<navigation-bar title="我的" back="{{false}}" color="black" background="#FFF"></navigation-bar>
 <scroll-view class="scrollarea" scroll-y type="list">
-  <view class="container">
-    <view class="userinfo">
-      <block wx:if="{{canIUseNicknameComp && !hasUserInfo}}">
-        <button class="avatar-wrapper" open-type="chooseAvatar" bind:chooseavatar="onChooseAvatar">
-          <image class="avatar" src="{{userInfo.avatarUrl}}"></image>
-        </button>
-        <view class="nickname-wrapper">
-          <text class="nickname-label">昵称</text>
-          <input type="nickname" class="nickname-input" placeholder="请输入昵称" bind:change="onInputChange" />
-        </view>
-      </block>
-      <block wx:elif="{{!hasUserInfo}}">
-        <button wx:if="{{canIUseGetUserProfile}}" bindtap="getUserProfile"> 获取头像昵称 </button>
-        <view wx:else> 请使用2.10.4及以上版本基础库 </view>
-      </block>
-      <block wx:else>
-        <image bindtap="bindViewTap" class="userinfo-avatar" src="{{userInfo.avatarUrl}}" mode="cover"></image>
-        <text class="userinfo-nickname">{{userInfo.nickName}}</text>
-      </block>
+  <view class="page-content">
+
+    <!-- ====== Profile Card (login preserved) ====== -->
+    <view class="profile-card">
+      <!-- <view class="profile-bg"></view> -->
+      <view class="profile-body">
+        <block wx:if="{{canIUseNicknameComp && !hasUserInfo}}">
+          <!-- Not logged in: avatar chooser + nickname input -->
+          <button class="avatar-wrapper" open-type="chooseAvatar" bind:chooseavatar="onChooseAvatar">
+            <image class="avatar" src="{{userInfo.avatarUrl}}"></image>
+          </button>
+          <view class="nickname-wrapper">
+            <text class="nickname-label">昵称</text>
+            <input type="nickname" class="nickname-input" placeholder="请输入昵称" bind:change="onInputChange" />
+          </view>
+        </block>
+        <block wx:elif="{{!hasUserInfo}}">
+          <button wx:if="{{canIUseGetUserProfile}}" class="login-btn" bindtap="getUserProfile">获取头像昵称</button>
+          <view wx:else class="compat-tip">请使用2.10.4及以上版本基础库</view>
+        </block>
+        <block wx:else>
+          <!-- Logged in: show avatar & name -->
+          <image bindtap="bindViewTap" class="userinfo-avatar" src="{{userInfo.avatarUrl}}" mode="cover"></image>
+          <text class="userinfo-nickname">{{userInfo.nickName}}</text>
+        </block>
+      </view>
     </view>
-    <view class="usermotto">
-      <text class="user-motto">{{motto}}</text>
+
+    <!-- ====== Appearance ====== -->
+    <van-cell-group title="外观设置" border="{{false}}" custom-class="settings-group">
+      <van-cell
+        title="深色模式"
+        is-link
+        value="{{themeLabel}}"
+        bindtap="showThemeSheet"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="bulb-o" class="cell-icon" color="#2F54EB" />
+      </van-cell>
+      <van-cell
+        title="首选语言"
+        is-link
+        value="{{languageLabel}}"
+        bindtap="showLanguageSheet"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="font-o" class="cell-icon" color="#597EF7" />
+      </van-cell>
+    </van-cell-group>
+
+    <!-- ====== Market Preferences ====== -->
+    <van-cell-group title="市场偏好" border="{{false}}" custom-class="settings-group">
+      <van-cell
+        title="默认市场"
+        is-link
+        value="{{defaultMarketLabel}}"
+        bindtap="showMarketSheet"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="chart-trending-o" class="cell-icon" color="#00B87A" />
+      </van-cell>
+    </van-cell-group>
+
+    <!-- ====== Notifications ====== -->
+    <van-cell-group title="消息通知" border="{{false}}" custom-class="settings-group">
+      <van-cell
+        title="订阅消息"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="bell" class="cell-icon" color="#FA8C16" />
+        <van-switch
+          slot="right-icon"
+          size="22px"
+          checked="{{subscriptionEnabled}}"
+          active-color="#2F54EB"
+          bind:change="onSubscriptionToggle"
+        />
+      </van-cell>
+      <van-cell
+        title="通知频率"
+        is-link
+        value="{{notifyFreqLabel}}"
+        bindtap="showNotifySheet"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="clock-o" class="cell-icon" color="#722ED1" />
+      </van-cell>
+    </van-cell-group>
+
+    <!-- ====== About ====== -->
+    <van-cell-group title="关于" border="{{false}}" custom-class="settings-group">
+      <van-cell
+        title="关于我们"
+        is-link
+        bindtap="goToAbout"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="info-o" class="cell-icon" color="#2F54EB" />
+      </van-cell>
+      <van-cell
+        title="意见反馈"
+        is-link
+        bindtap="goToFeedback"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="comment-o" class="cell-icon" color="#13C2C2" />
+      </van-cell>
+      <van-cell
+        title="当前版本"
+        value="{{appVersion}}"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="apps-o" class="cell-icon" color="#8C92A4" />
+      </van-cell>
+    </van-cell-group>
+
+    <!-- ====== Logout ====== -->
+    <view wx:if="{{hasUserInfo}}" class="logout-section">
+      <view class="logout-btn" bindtap="onLogout">退出登录</view>
     </view>
+
+    <!-- ====== ActionSheets ====== -->
+    <van-action-sheet
+      show="{{showThemeSheet}}"
+      actions="{{themeActions}}"
+      cancel-text="取消"
+      bind:close="onThemeSheetClose"
+      bind:cancel="onThemeSheetClose"
+      bind:select="onThemeSelect"
+    />
+
+    <van-action-sheet
+      show="{{showMarketSheet}}"
+      actions="{{marketActions}}"
+      cancel-text="取消"
+      bind:close="onMarketSheetClose"
+      bind:cancel="onMarketSheetClose"
+      bind:select="onMarketSelect"
+    />
+
+    <van-action-sheet
+      show="{{showNotifySheet}}"
+      actions="{{notifyActions}}"
+      cancel-text="取消"
+      bind:close="onNotifySheetClose"
+      bind:cancel="onNotifySheetClose"
+      bind:select="onNotifyFreqSelect"
+    />
+
+    <van-action-sheet
+      show="{{showLanguageSheet}}"
+      actions="{{languageActions}}"
+      cancel-text="取消"
+      bind:close="onLanguageSheetClose"
+      bind:cancel="onLanguageSheetClose"
+      bind:select="onLanguageSelect"
+    />
+
   </view>
 </scroll-view>


### PR DESCRIPTION
The index page was previously a basic login stub. To provide a personalized user experience, this change transforms it into a comprehensive settings portal while strictly preserving the existing login functionality.

This commit integrates Vant Cell components to introduce configurations for theme (light/dark/system), preferred language, default market, and subscription notifications. All tracking preferences are persisted to local storage. New static "About Us" and "Feedback" sub-pages were created and registered in app.json. Furthermore, Chinese comments in index.wxml were converted to English to follow project conventions.

TODO: This commit only implements the UI. The underlying triggering logic still needs to be implemented.

Related Issue: #3 