### PR TITLE
SF-00 ci: implement GitHub status reporting in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,12 @@ pipeline {
                 // Test: Can we successfully pull the latest code from GitHub?
                 checkout scm
                 echo 'Code checkout successful!'
+
+                echo "Code checkout successful! Commit SHA: ${env.GIT_COMMIT}"
+                
+                // 3. Now it is safe to notify GitHub that we are starting
+                // Note: GitHub Status API uses 'pending', 'success', 'failure', or 'error'
+                publishGitHubStatus('pending', 'Pipeline Started: Checking out code...')
             }
         }
 
@@ -39,6 +45,9 @@ pipeline {
 
         stage('Compile & Check') {
             steps {
+                // 2. Update check to Compiling
+                publishGitHubStatus('pending', 'Compiling Code: Running miniprogram-ci...')
+
                 // Now both variables are available in the environment
                 sh 'npm run check' 
             }
@@ -56,11 +65,46 @@ pipeline {
     post {
         success {
             echo 'Congratulations! The test pipeline is fully connected! The GitHub Webhook and Jenkins Docker agent are working perfectly together.'
+
+            // 3. Send SUCCESS check
+            publishGitHubStatus('success', 'Compilation Passed. Click Details to view QR.')
+
             // show QR fig
             archiveArtifacts artifacts: 'preview_QR.jpg', allowEmptyArchive: true
         }
         failure {
             echo 'Test run failed. Please check the logs above to see which step caused the error.'
+            
+            // 4. Send FAILURE check
+            publishGitHubStatus('failure', 'Compilation Failed. Check Jenkins logs.')
+        }
+    }
+}
+
+// ==============================================================================
+// Helper Function: Call GitHub Status API directly (Bulletproof Version)
+// ==============================================================================
+def publishGitHubStatus(state, description) {
+    script {
+        // Use the native Jenkins Git variable
+        def commitSha = env.GIT_COMMIT
+
+        def repoPath = 'days0102/StocksFlow' 
+        def contextName = 'Jenkins / Deep Compilation Check'
+        
+        // Build JSON payload as a string to avoid file read/write issues
+        def payloadString = """{"state": "${state}", "target_url": "${env.RUN_DISPLAY_URL}", "description": "${description}", "context": "${contextName}"}"""
+
+        // Use your correctly configured credential ID here
+        withCredentials([string(credentialsId: 'Jenkins_to_Github_StockFlow', variable: 'GITHUB_TOKEN')]) {
+            sh """
+            curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer \${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${repoPath}/statuses/${commitSha} \
+            -d '${payloadString}'
+            """
         }
     }
 }

--- a/script/commit-msg
+++ b/script/commit-msg
@@ -43,13 +43,13 @@ fi
 #   - Component: single lowercase word from the allowed list (section 2.1)
 #   - Description: non-empty
 # ---------------------------------------------------------------------------
-ALLOWED_COMPONENTS="pages|components|utils|api|cloud|styles|store|config|docs|all|script|tests"
+ALLOWED_COMPONENTS="pages|components|utils|api|cloud|styles|store|config|docs|all|script|tests|ci"
 SUMMARY_REGEX="^(SF-[0-9]+|#[0-9]+) ($ALLOWED_COMPONENTS): .+"
 
 if ! echo "$SUMMARY_LINE" | grep -Eq "$SUMMARY_REGEX"; then
     error "Summary line does not match required format."
     error "  Expected : <SF-NNN|#NNN> <component>: <description>"
-    error "  Components: pages, components, utils, api, cloud, styles, store, config, docs, all, script, tests"
+    error "  Components: pages, components, utils, api, cloud, styles, store, config, docs, all, script, tests, ci"
     error "  Got       : \"${SUMMARY_LINE}\""
     ERRORS=$((ERRORS + 1))
 fi


### PR DESCRIPTION
Jenkins return the pipeline status to show on Github.

- Add status reporting (pending, success, failure) to GitHub UI.
- `publishGitHubStatus` helper to dynamically update commit status.
- Trigger 'pending' state during checkout and compilation stages.
- Trigger 'success' or 'failure' state in post-build actions.