### PR TITLE
SF-03 pages: transform logs into operation history with new UI

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -5,7 +5,8 @@
     "pages/logs/logs",
     "pages/calendar/calendar",
     "pages/about/about",
-    "pages/feedback/feedback"
+    "pages/feedback/feedback",
+    "pages/notification/notification"
   ],
   "window": {
     "navigationBarTextStyle": "black",
@@ -13,31 +14,32 @@
   },
   "tabBar": {
     "selectedColor": "#3f72af",
-    "list": [{
-      "pagePath": "pages/market/market",
-      "text": "时间",
-      "iconPath": "public/time.png",
-      "selectedIconPath": "public/time_active.png"
-    },
-    {
-      "pagePath": "pages/calendar/calendar",
-      "text": "日历",
-      "iconPath": "public/calendar.png",
-      "selectedIconPath": "public/calendar_active.png"
-    },
-    {
-      "pagePath": "pages/logs/logs",
-      "text": "通知",
-      "iconPath": "public/notification.png",
-      "selectedIconPath": "public/notification_active.png"
-    },
-    {
-      "pagePath": "pages/index/index",
-      "text": "我的",
-      "iconPath": "public/profile.png",
-      "selectedIconPath": "public/profile_active.png"
-    }
-  ]
+    "list": [
+      {
+        "pagePath": "pages/market/market",
+        "text": "时间",
+        "iconPath": "public/time.png",
+        "selectedIconPath": "public/time_active.png"
+      },
+      {
+        "pagePath": "pages/calendar/calendar",
+        "text": "日历",
+        "iconPath": "public/calendar.png",
+        "selectedIconPath": "public/calendar_active.png"
+      },
+      {
+        "pagePath": "pages/notification/notification",
+        "text": "通知",
+        "iconPath": "public/notification.png",
+        "selectedIconPath": "public/notification_active.png"
+      },
+      {
+        "pagePath": "pages/index/index",
+        "text": "我的",
+        "iconPath": "public/profile.png",
+        "selectedIconPath": "public/profile_active.png"
+      }
+    ]
   },
   "style": "v2",
   "rendererOptions": {

--- a/miniprogram/app.less
+++ b/miniprogram/app.less
@@ -1,4 +1,19 @@
 /**app.wxss**/
+
+/**
+* fix bug
+* Failed to load font http://at.alicdn.com/t/c/font_2553510_kfwma2yq1rs.woff2?t=1694918397022
+* net::ERR_CACHE_MISS 
+* (env: Windows,mp,2.01.2510290; lib: 2.32.3)
+*/
+@font-face {
+  font-family: 'vant-icon';
+  font-style: normal;
+  font-weight: 400;
+  src: url("https://at.alicdn.com/t/c/font_2553510_kfwma2yq1rs.woff2?t=1694918397022") format("woff2"),
+    url("https://at.alicdn.com/t/c/font_2553510_kfwma2yq1rs.woff?t=1694918397022") format("woff");
+}
+
 .container {
   height: 100%;
   display: flex;
@@ -7,4 +22,4 @@
   justify-content: space-between;
   padding: 200rpx 0;
   box-sizing: border-box;
-} 
+}

--- a/miniprogram/app.ts
+++ b/miniprogram/app.ts
@@ -1,11 +1,15 @@
 // app.ts
+import { addLog } from './utils/util'
+
 App<IAppOption>({
   globalData: {},
   onLaunch() {
-    // 展示本地存储能力
-    const logs = wx.getStorageSync('logs') || []
-    logs.unshift(Date.now())
-    wx.setStorageSync('logs', logs)
+    let logs = wx.getStorageSync('logs') || []
+    if (logs.length > 0 && typeof logs[0] === 'number') {
+      logs = logs.map((time: number) => ({ time, action: '应用启动', detail: 'App Launch' }))
+      wx.setStorageSync('logs', logs)
+    }
+    addLog('应用启动', '小程序拉起/初始化')
 
     // 登录
     wx.login({

--- a/miniprogram/pages/about/about.ts
+++ b/miniprogram/pages/about/about.ts
@@ -2,5 +2,19 @@
 Component({
   data: {
     appVersion: 'v0.1.0',
+    githubLink: 'https://github.com/days0102/StocksFlow',
   },
+  methods: {
+    copyGithubLink() {
+      wx.setClipboardData({
+        data: this.data.githubLink,
+        success() {
+          wx.showToast({
+            title: '链接已复制',
+            icon: 'success'
+          })
+        }
+      })
+    }
+  }
 })

--- a/miniprogram/pages/about/about.wxml
+++ b/miniprogram/pages/about/about.wxml
@@ -54,6 +54,15 @@
         <van-icon slot="icon" name="friends-o" class="cell-icon" color="#2F54EB" />
       </van-cell>
       <van-cell
+        title="开源主页"
+        value="复制 GitHub 链接"
+        is-link
+        bindtap="copyGithubLink"
+        custom-class="contact-cell"
+      >
+        <van-icon slot="icon" name="cluster-o" class="cell-icon" color="#333333" />
+      </van-cell>
+      <van-cell
         title="技术支持"
         title-width="160rpx"
         center

--- a/miniprogram/pages/index/index.ts
+++ b/miniprogram/pages/index/index.ts
@@ -2,6 +2,7 @@
 // Get an example of the application
 const app = getApp<IAppOption>()
 const defaultAvatarUrl = 'https://mmbiz.qpic.cn/mmbiz/icTdbqWNOwNRna42FI242Lcia07jQodd2FJGIYQfG0LAJGFxM4FbnQP6yfMxBgJ0F3YRqJCJ1aPAK2dQagdusBZg/0'
+import { addLog } from '../../utils/util'
 
 // ── Label maps ──
 const THEME_MAP: Record<string, string> = {
@@ -168,6 +169,7 @@ Component({
 
     saveSettings(key: string, value: any) {
       wx.setStorageSync(`settings_${key}`, value)
+      // Only log specific setting changes explicitly in their specific handlers to provide better localized labels 
     },
 
     // ============================================================
@@ -187,6 +189,7 @@ Component({
         showThemeSheet: false,
       })
       this.saveSettings('themeMode', value)
+      addLog('更改主题模式', `变更为: ${THEME_MAP[value]}`)
       wx.showToast({ title: '已切换为' + THEME_MAP[value], icon: 'none', duration: 1500 })
     },
 
@@ -207,6 +210,7 @@ Component({
         showLanguageSheet: false,
       })
       this.saveSettings('language', value)
+      addLog('更改首选语言', `变更为: ${LANGUAGE_MAP[value]}`)
       wx.showToast({ title: '语言已设为' + LANGUAGE_MAP[value], icon: 'none', duration: 1500 })
     },
 
@@ -227,6 +231,7 @@ Component({
         showMarketSheet: false,
       })
       this.saveSettings('defaultMarket', value)
+      addLog('更改默认市场', `变更为: ${MARKET_MAP[value]}`)
       wx.showToast({ title: '默认市场已设为' + MARKET_MAP[value], icon: 'none', duration: 1500 })
     },
 
@@ -237,6 +242,7 @@ Component({
       const enabled = e.detail
       this.setData({ subscriptionEnabled: enabled })
       this.saveSettings('subscriptionEnabled', enabled)
+      addLog('消息订阅服务', enabled ? '开启订阅服务' : '关闭订阅服务')
 
       if (enabled) {
         // Request subscription message permission
@@ -268,12 +274,16 @@ Component({
         showNotifySheet: false,
       })
       this.saveSettings('notifyFrequency', value)
+      addLog('更改通知频率', `变更为: ${NOTIFY_FREQ_MAP[value]}`)
       wx.showToast({ title: '通知频率已设为' + NOTIFY_FREQ_MAP[value], icon: 'none', duration: 1500 })
     },
 
     // ============================================================
     // Navigation
     // ============================================================
+    goToLogs() {
+      wx.navigateTo({ url: '/pages/logs/logs' })
+    },
     goToAbout() {
       wx.navigateTo({ url: '/pages/about/about' })
     },
@@ -299,6 +309,7 @@ Component({
             })
             this.saveSettings('userInfo', null)
             this.saveSettings('hasUserInfo', false)
+            addLog('退出登录', '账号已注销')
             wx.showToast({ title: '已退出登录', icon: 'none' })
           }
         }

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -93,6 +93,14 @@
     <!-- ====== About ====== -->
     <van-cell-group title="关于" border="{{false}}" custom-class="settings-group">
       <van-cell
+        title="操作日志"
+        is-link
+        bindtap="goToLogs"
+        custom-class="settings-cell"
+      >
+        <van-icon slot="icon" name="notes-o" class="cell-icon" color="#FA541C" />
+      </van-cell>
+      <van-cell
         title="关于我们"
         is-link
         bindtap="goToAbout"

--- a/miniprogram/pages/logs/logs.json
+++ b/miniprogram/pages/logs/logs.json
@@ -1,5 +1,6 @@
 {
   "usingComponents": {
-    "navigation-bar": "/components/navigation-bar/navigation-bar"
+    "navigation-bar": "/components/navigation-bar/navigation-bar",
+    "van-icon": "@vant/weapp/icon/index"
   }
 }

--- a/miniprogram/pages/logs/logs.less
+++ b/miniprogram/pages/logs/logs.less
@@ -1,16 +1,141 @@
+@bg-color: #F5F6F8;
+@surface-color: #FFFFFF;
+@primary-color: #2F54EB;
+@text-main: #1A1D24;
+@text-secondary: #8C92A4;
+@border-color: #EBF0F5;
+
 page {
   height: 100vh;
   display: flex;
   flex-direction: column;
+  background-color: @bg-color;
 }
+
 .scrollarea {
   flex: 1;
   overflow-y: hidden;
 }
-.log-item {
-  margin-top: 20rpx;
-  text-align: center;
+
+.logs-page {
+  padding: 40rpx 40rpx calc(64rpx + env(safe-area-inset-bottom));
 }
-.log-item:last-child {
-  padding-bottom: env(safe-area-inset-bottom);
+
+// ==========================================
+// Empty State
+// ==========================================
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-top: 240rpx;
+
+  .empty-image {
+    width: 200rpx;
+    height: 200rpx;
+    margin-bottom: 40rpx;
+    opacity: 0.2;
+    filter: grayscale(100%);
+  }
+
+  .empty-text {
+    font-size: 28rpx;
+    color: @text-secondary;
+    letter-spacing: 1rpx;
+  }
 }
+
+// ==========================================
+// List Glass Container
+// ==========================================
+.logs-list-glass {
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: 32rpx;
+  padding: 16rpx 0;
+  box-shadow: 0 12rpx 32rpx rgba(30, 41, 59, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+}
+
+// ==========================================
+// Row Item Layout
+// ==========================================
+.log-item-row {
+  display: flex;
+  align-items: flex-start;
+  padding: 0 32rpx;
+  transition: background-color 0.2s ease;
+
+  &:active {
+    background-color: rgba(0, 0, 0, 0.02);
+  }
+}
+
+// ==========================================
+// Icon Orbs (Gradients)
+// ==========================================
+.icon-orb {
+  width: 80rpx;
+  height: 80rpx;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 24rpx;
+  margin-right: 28rpx;
+  flex-shrink: 0;
+  box-shadow: 0 4rpx 12rpx rgba(0, 0, 0, 0.08);
+
+  &.bg-blue { background: linear-gradient(135deg, #1890FF, #096DD9); box-shadow: 0 4rpx 16rpx rgba(24, 144, 255, 0.25); }
+  &.bg-purple { background: linear-gradient(135deg, #9C2CF3, #3A49F9); box-shadow: 0 4rpx 16rpx rgba(156, 44, 243, 0.25); }
+  &.bg-green { background: linear-gradient(135deg, #00C6FF, #0072FF); box-shadow: 0 4rpx 16rpx rgba(0, 114, 255, 0.25); }
+  &.bg-orange { background: linear-gradient(135deg, #FF8C00, #FF512F); box-shadow: 0 4rpx 16rpx rgba(255, 81, 47, 0.25); }
+  &.bg-cyan { background: linear-gradient(135deg, #00F2FE, #4FACFE); box-shadow: 0 4rpx 16rpx rgba(79, 172, 254, 0.25); }
+  &.bg-red { background: linear-gradient(135deg, #FF416C, #FF4B2B); box-shadow: 0 4rpx 16rpx rgba(255, 75, 43, 0.25); }
+  &.bg-gray { background: linear-gradient(135deg, #8E9EAB, #EEF2F3); }
+}
+
+// ==========================================
+// Right Content Column
+// ==========================================
+.content-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 32rpx 0;
+  border-bottom: 2rpx solid rgba(0, 0, 0, 0.04);
+  
+  &.no-border {
+    border-bottom: none;
+  }
+}
+
+.top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8rpx;
+
+  .action-title {
+    font-size: 32rpx;
+    font-weight: 600;
+    color: @text-main;
+  }
+
+  .time-label {
+    font-size: 24rpx;
+    color: @text-secondary;
+    font-weight: 500;
+  }
+}
+
+.bottom-row {
+  .detail-label {
+    font-size: 26rpx;
+    color: @text-secondary;
+    line-height: 1.4;
+  }
+}
+

--- a/miniprogram/pages/logs/logs.ts
+++ b/miniprogram/pages/logs/logs.ts
@@ -1,21 +1,56 @@
 // logs.ts
-// const util = require('../../utils/util.js')
 import { formatTime } from '../../utils/util'
+
+const formatShortTime = (date: Date) => {
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const day = date.getDate().toString().padStart(2, '0')
+  const hour = date.getHours().toString().padStart(2, '0')
+  const minute = date.getMinutes().toString().padStart(2, '0')
+  return `${month}-${day} ${hour}:${minute}`
+}
+
+function getLogMeta(action: string) {
+  if (action.includes('启动')) return { icon: 'apps-o', bg: 'bg-blue' }
+  if (action.includes('主题') || action.includes('外观')) return { icon: 'bulb-o', bg: 'bg-purple' }
+  if (action.includes('市场')) return { icon: 'chart-trending-o', bg: 'bg-green' }
+  if (action.includes('语言')) return { icon: 'font-o', bg: 'bg-orange' }
+  if (action.includes('消息') || action.includes('通知')) return { icon: 'bell', bg: 'bg-cyan' }
+  if (action.includes('登录')) return { icon: 'user-circle-o', bg: 'bg-red' }
+  return { icon: 'setting-o', bg: 'bg-gray' }
+}
 
 Component({
   data: {
-    logs: [],
+    logs: [] as any[],
   },
   lifetimes: {
     attached() {
-      this.setData({
-        logs: (wx.getStorageSync('logs') || []).map((log: string) => {
-          return {
-            date: formatTime(new Date(log)),
-            timeStamp: log
-          }
-        }),
+      const logs = (wx.getStorageSync('logs') || []).map((log: any) => {
+        let actionStr = '应用启动'
+        let detailStr = ''
+        let logTime = Date.now()
+
+        if (typeof log === 'number') {
+          logTime = log
+        } else {
+          logTime = log.time
+          actionStr = log.action
+          detailStr = log.detail
+        }
+
+        const meta = getLogMeta(actionStr)
+
+        return {
+          date: formatTime(new Date(logTime)),
+          dateShort: formatShortTime(new Date(logTime)),
+          timeStamp: logTime,
+          action: actionStr,
+          detail: detailStr,
+          icon: meta.icon,
+          bgClass: meta.bg
+        }
       })
+      this.setData({ logs })
     }
   },
 })

--- a/miniprogram/pages/logs/logs.wxml
+++ b/miniprogram/pages/logs/logs.wxml
@@ -1,7 +1,34 @@
 <!--logs.wxml-->
-<navigation-bar title="查看启动日志" back="{{true}}" color="black" background="#FFF"></navigation-bar>
+<navigation-bar title="操作日志" back="{{true}}" color="black" background="#FFF"></navigation-bar>
 <scroll-view class="scrollarea" scroll-y type="list">
-  <block wx:for="{{logs}}" wx:key="timeStamp" wx:for-item="log">
-    <view class="log-item">{{index + 1}}. {{log.date}}</view>
-  </block>
+  <view class="logs-page">
+    <block wx:if="{{logs.length === 0}}">
+      <view class="empty-state">
+        <image class="empty-image" src="/public/notification.png" mode="aspectFit"></image>
+        <text class="empty-text">系统很安静，暂无活动记录</text>
+      </view>
+    </block>
+
+    <view class="logs-list-glass" wx:else>
+      <view class="log-item-row" wx:for="{{logs}}" wx:key="timeStamp">
+        
+        <!-- Orb Icon -->
+        <view class="icon-orb {{item.bgClass}}">
+          <van-icon name="{{item.icon}}" size="40rpx" color="#FFF" />
+        </view>
+
+        <!-- Right Content -->
+        <view class="content-col {{index === logs.length - 1 ? 'no-border' : ''}}">
+           <view class="top-row">
+             <text class="action-title">{{item.action}}</text>
+             <text class="time-label">{{item.dateShort}}</text>
+           </view>
+           <view class="bottom-row" wx:if="{{item.detail}}">
+             <text class="detail-label">{{item.detail}}</text>
+           </view>
+        </view>
+
+      </view>
+    </view>
+  </view>
 </scroll-view>

--- a/miniprogram/pages/notification/notification.json
+++ b/miniprogram/pages/notification/notification.json
@@ -1,0 +1,5 @@
+{
+  "usingComponents": {
+    "navigation-bar": "/components/navigation-bar/navigation-bar"
+  }
+}

--- a/miniprogram/pages/notification/notification.less
+++ b/miniprogram/pages/notification/notification.less
@@ -1,0 +1,19 @@
+page {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.scrollarea {
+  flex: 1;
+  overflow-y: hidden;
+}
+
+.log-item {
+  margin-top: 20rpx;
+  text-align: center;
+}
+
+.log-item:last-child {
+  padding-bottom: env(safe-area-inset-bottom);
+}

--- a/miniprogram/pages/notification/notification.ts
+++ b/miniprogram/pages/notification/notification.ts
@@ -1,0 +1,21 @@
+// logs.ts
+// const util = require('../../utils/util.js')
+import { formatTime } from '../../utils/util'
+
+Component({
+  data: {
+    logs: [],
+  },
+  lifetimes: {
+    attached() {
+      this.setData({
+        logs: (wx.getStorageSync('logs') || []).map((log: string) => {
+          return {
+            date: formatTime(new Date(log)),
+            timeStamp: log
+          }
+        }),
+      })
+    }
+  },
+})

--- a/miniprogram/pages/notification/notification.wxml
+++ b/miniprogram/pages/notification/notification.wxml
@@ -1,0 +1,8 @@
+<!--logs.wxml-->
+<navigation-bar title="查看启动日志" back="{{true}}" color="black" background="#FFF"></navigation-bar>
+
+<scroll-view class="scrollarea" scroll-y type="list">
+  <block wx:for="{{logs}}" wx:key="timeStamp" wx:for-item="log">
+    <view class="log-item">{{index + 1}}. {{log.date}}</view>
+  </block>
+</scroll-view>

--- a/miniprogram/utils/util.ts
+++ b/miniprogram/utils/util.ts
@@ -17,3 +17,14 @@ const formatNumber = (n: number) => {
   const s = n.toString()
   return s[1] ? s : '0' + s
 }
+
+export const addLog = (action: string, detail: string = '') => {
+  const logs = wx.getStorageSync('logs') || []
+  logs.unshift({
+    time: Date.now(),
+    action,
+    detail
+  })
+  if (logs.length > 50) logs.pop()
+  wx.setStorageSync('logs', logs)
+}


### PR DESCRIPTION
To better track user preference changes and application events, the default startup logs feature was refactored into a comprehensive operation history tracker.

The `pages/logs/logs` page was converted into a dedicated sub-page accessible from the Settings panel. A new `addLog` utility was created to record structured data including actions and details. This tracker now captures app launches, complete settings updates (theme, language, market, subscriptions), and logout events.

Additionally, the log UI was completely redesigned using a premium layout, featuring glassmorphism containers, dynamic gradient icon orbs based on action types, and refined typography. The original notifications tab was effectively migrated to a new `notification` page to preserve the app's structure.

Relate Issue: #3 
Relate RP: #13